### PR TITLE
Fixed Pointer issues and paths to header files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # c-containers
 Uses memory container from the following repo: https://github.com/FatalSleep/null-terminated-memory
 
-CVector is a derivative of iDestinyKK's CN_Vec: https://github.com/iDestyKK/CN_Vec
+CVector is a derivative of iDestyKK's CN_Vec: https://github.com/iDestyKK/CN_Vec
 
 Dynamic memory containers for C:
 - CArray (generic container)

--- a/base/carray.c
+++ b/base/carray.c
@@ -1,7 +1,7 @@
 #include "carray.h"
 #pragma region Alloc / Free
 carray* ca_alloc(ui32 structsz, ui32 typesz, ui32 cachesz) {
-    carray* cstk = (carray*) calloc(structsz, sizeof(ui08));
+    carray* cstk = (carray*) calloc(structsz, typesz);
     cstk->typesz = typesz;
     cstk->cachesz = cachesz;
     cstk->length = 0;

--- a/base/carray.c
+++ b/base/carray.c
@@ -1,7 +1,7 @@
 #include "carray.h"
 #pragma region Alloc / Free
 carray* ca_alloc(ui32 structsz, ui32 typesz, ui32 cachesz) {
-    carray* cstk = (carray*) calloc(structsz, typesz);
+    carray* cstk = (carray*) calloc(structsz, sizeof(ui08));
     cstk->typesz = typesz;
     cstk->cachesz = cachesz;
     cstk->length = 0;

--- a/base/carray.h
+++ b/base/carray.h
@@ -17,7 +17,7 @@
 #define C_ARRAY
     #include <stdlib.h>
     #include <string.h>
-    #include "memory.h"
+    #include "../memory/memory.h"
     
     typedef unsigned int ui32;
     typedef unsigned char ui08;
@@ -39,7 +39,7 @@
     typedef struct ca_iter {
         void* memory;
         ui08* iteration;
-        enum cbiterpos iterpos;
+        cbiterpos iterpos;
     } cbiter;
 
     carray* ca_alloc(ui32 strcsz, ui32 typesz, ui32 cachesz);

--- a/cstack.c
+++ b/cstack.c
@@ -2,7 +2,7 @@
 
 #pragma region Top / Push / Pop
 type cs_top(cstack* cstk) {
-    return (type) *(cstk->memory->pointer + ((cstk->length - 1) * cstk->typesz));
+    return (type) (cstk->memory->pointer + ((cstk->length - 1) * cstk->typesz));
 };
 
 void cs_push(cstack* cstk, type data) {

--- a/cstack.h
+++ b/cstack.h
@@ -2,7 +2,7 @@
 #define C_STACK
     #include <stdlib.h>
     #include <string.h>
-    #include "carray.h"
+    #include "base/carray.h"
 
     typedef struct c_stack {
         ui32 typesz, cachesz, length, cached;

--- a/cvector.c
+++ b/cvector.c
@@ -7,8 +7,8 @@ void cv_pushback(cvector* cvec, type data) {
 
     memcpy(cvec->memory->pointer + (cvec->length * cvec->typesz), data, cvec->typesz);
     
-    cvec->length ++;
-    cvec->cached --;
+    cvec->length++;
+    cvec->cached--;
 };
 
 void cv_pushfront(cvector* cvec, type data) {
@@ -56,7 +56,7 @@ void cv_remove(cvector* cvec, ui32 pos) {
 
 #pragma region Set / Get
 type cv_get(cvector* cvec, ui32 pos) {
-    return (type) *(cvec->memory->pointer + (pos * cvec->typesz));
+    return (type) (cvec->memory->pointer + (pos * cvec->typesz));
 };
 
 void cv_set(cvector* cvec, ui32 pos, type data) {

--- a/cvector.h
+++ b/cvector.h
@@ -2,7 +2,7 @@
 #define C_VECTOR
     #include <stdlib.h>
     #include <string.h>
-    #include "carray.h"
+    #include "base/carray.h"
 
     typedef struct c_vector {
         ui32 typesz, cachesz, length, cached;


### PR DESCRIPTION
Fixed typo in README.md of my username, and also #include paths for libraries in sub-directories.
Also fixed how functions such as cs_top and cv_get were pointing to addresses like 0x1 rather than addresses to the member in the memory struct.